### PR TITLE
function formatDocument is no more needed

### DIFF
--- a/app/controllers/TaskController.php
+++ b/app/controllers/TaskController.php
@@ -5,20 +5,13 @@ class TaskController extends Controller
     {
         // Get all tasks and display them
         $taskModel = new Task();
-        // We send documents array to function formatDocument to nulled the date if unix timestamp = 0
-        foreach ($taskModel->getAllTasks() as $key => $data) {
-            $tasks[$key] = $this->formatDocument($data);
-        }
-        $this->view->message = $tasks;
+        $this->view->message = $taskModel->getAllTasks();
     }
 
     public function createTaskAction()
     {
         // If form is sent
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-
-            // We send document to function formatDocument to nulled the date if it has empty string
-            $this->formatDocument($_POST);
 
             // Check if data is validated and retrieves $validatedData array
             if ($validatedData = $this->validateForm($_POST)) {
@@ -50,10 +43,7 @@ class TaskController extends Controller
         $taskId = $_POST['id'];
         // We get the document by id
         $taskById = $taskModel->getTaskById($taskId);
-        // We send document to function formatDocument to nulled the date if unix timestamp = 0
-        $this->formatDocument($taskById);
-        // Send to the view
-        $this->view->taskData = $taskById;
+        $this->view->taskData = $taskModel->getTaskById($taskId);
 
         // If form is sent, validate data
         if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['updateButton'])) {
@@ -141,24 +131,11 @@ class TaskController extends Controller
         $data = trim($data);
         $data = stripslashes($data);
         $data = htmlspecialchars($data);
-        // If form return empty string, convert to null value to match MySql field types
+        // If form return empty string, convert to null value to match BSON field types
         if ($data == '') {
             $data = null;
         }
         return $data;
-    }
-
-    // Function that nulled the date if unix timestamp is = 0 or empty string
-    public function formatDocument($document)
-    {
-        if ($document['dateTimeStarted'] == '0' || $document['dateTimeStarted'] == '') {
-            $document['dateTimeStarted'] = null;
-        }
-
-        if ($document['dateTimeFinished'] == '0' || $document['dateTimeFinished'] == '') {
-            $document['dateTimeFinished'] = null;
-        }
-        return $document;
     }
 
     // If date is null we pass the null value to mongodb

--- a/web/db/tasks.dmm
+++ b/web/db/tasks.dmm
@@ -66,7 +66,7 @@
 					"comment": "",
 					"data": "",
 					"enum": "",
-					"validation": "",
+					"validation": "['date', 'null']",
 					"pattern": false,
 					"estimatedSize": "",
 					"any": ""
@@ -82,7 +82,7 @@
 					"comment": "",
 					"data": "",
 					"enum": "",
-					"validation": "",
+					"validation": "['date', 'null']",
 					"pattern": false,
 					"estimatedSize": "",
 					"any": ""
@@ -126,8 +126,8 @@
 			"customCode": "",
 			"beforeScript": "",
 			"afterScript": "",
-			"validationLevel": "na",
-			"validationAction": "na",
+			"validationLevel": "strict",
+			"validationAction": "error",
 			"collation": "",
 			"others": "",
 			"size": "",
@@ -173,7 +173,8 @@
 		"def_validationAction": "na",
 		"def_collation": "",
 		"def_others": "",
-		"connectionVersion": ""
+		"connectionVersion": "",
+		"lastSaved": 1713601895461
 	},
 	"otherObjects": {},
 	"diagrams": {


### PR DESCRIPTION
La función formatDocument gestionaba el valor de los campos date en caso que mongodb devolviera un valor unix timestamp = 0.
Ahora que los campos date aceptan un valor null, ese supuesto ya no existe y la función ya no es necesaria.